### PR TITLE
Add two example invariants to catamaran-sbtc

### DIFF
--- a/catamaran-sbtc/contracts/btc-sbtc-swap.tests.clar
+++ b/catamaran-sbtc/contracts/btc-sbtc-swap.tests.clar
@@ -19,3 +19,28 @@
   (let ((balance (unwrap-panic (contract-call? 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token get-balance (as-contract tx-sender)))))
     (or (is-eq (var-get next-id) u0) (> balance u0))
   ))
+
+(define-read-only (invariant-positive-contract-balance)
+  (let
+    (
+      (num-calls-create-swap (default-to u0 (get called (map-get? context "create-swap"))))
+      (num-calls-cancel (default-to u0 (get called (map-get? context "cancel"))))
+      (balance (unwrap-panic (contract-call? 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token get-balance (as-contract tx-sender))))
+    )
+    (if
+      (is-eq num-calls-create-swap num-calls-cancel)
+      true
+      (> balance u0)
+    )
+  )
+)
+
+(define-read-only (invariant-less-eq-cancels-than-swaps)
+  (let
+    (
+      (num-calls-create-swap (default-to u0 (get called (map-get? context "create-swap"))))
+      (num-calls-cancel (default-to u0 (get called (map-get? context "cancel"))))
+    )
+    (>= num-calls-create-swap num-calls-cancel)
+  )
+)


### PR DESCRIPTION
This PR adds two example invariants for the `btc-sbtc-swap` contract. The invariants showcase the Rendezvous `context` usage. More about using the context [here](https://stacks-network.github.io/rendezvous/chapter_6.html#the-rendezvous-context).